### PR TITLE
Fixing MongoDB connection leask

### DIFF
--- a/lib/message-queue.js
+++ b/lib/message-queue.js
@@ -107,24 +107,32 @@ function MessageQueue() {
 
   function _enqueue(queueItem) {
     if (!self.databasePromise) { return Q.reject(new Error("No database configured")); }
+    var dbconn;
     return self.databasePromise()
       .then(function(db) {
+    	  dbconn = db;
         return db.collection(self.collectionName).insertOne(queueItem);
       })
       .then(function(result) {
         return result.ops[0];
-      });
+      })
+      .then(function() {dbconn.close()})
+      ;
   }
 
   function _dequeue(queueItem) {
     if (!self.databasePromise) { return Q.reject(new Error("No database configured")); }
+    var dbconn;
     return self.databasePromise()
       .then(function(db) {
+    	  dbconn = db;
         return db.collection(self.collectionName).deleteOne({_id: queueItem._id});
       })
       .then(function(result) {
         return result.deletedCount;
-      });
+      })
+      .then(function() {dbconn.close()})
+      ;
   }
 
   function _release(queueItem) {
@@ -147,13 +155,17 @@ function MessageQueue() {
     };
 
     if (!self.databasePromise) { return Q.reject(new Error("No database configured")); }
+    var dbconn;
     return self.databasePromise()
       .then(function(db) {
+    	  dbconn = db;
         return db.collection(self.collectionName).updateOne({_id: queueItem._id}, update);
       })
       .then(function(result) {
         return result.modifiedCount;
-      });
+      })
+      .then(function(){dbconn.close()})
+      ;
   }
 
   function _reject(queueItem) {
@@ -177,13 +189,16 @@ function MessageQueue() {
     };
 
     if (!self.databasePromise) { return Q.reject(new Error("No database configured")); }
+    var dbconn;
     return self.databasePromise()
       .then(function(db) {
+    	  dbconn = db;
         return db.collection(self.collectionName).updateOne({_id: queueItem._id}, update);
       })
       .then(function(result) {
         return result.modifiedCount;
-      });
+      })
+      .then(function(){dbconn.close()});
   }
 
   function _receive() {
@@ -212,13 +227,16 @@ function MessageQueue() {
     };
 
     if (!self.databasePromise) { return Q.reject(new Error("No database configured")); }
+    var dbconn;
     return self.databasePromise()
       .then(function(db) {
+    	  dbconn = db;
         return db.collection(self.collectionName).findOneAndUpdate(query, update, {returnOriginal: false});
       })
       .then(function(result) {
         return result.value;
-      });
+      })
+      .then(function(){dbconn.close()});
   }
 
   //endregion


### PR DESCRIPTION
The mongo db connections were not closed and causing MongoDB server to run out of connections.  Added the dbconn.close() after finished with the connections to methods where the connection were open.
